### PR TITLE
fix: SimulatePriceComponent selected plan estimations

### DIFF
--- a/src/components/SimulatePriceComponent.tsx
+++ b/src/components/SimulatePriceComponent.tsx
@@ -218,11 +218,11 @@ export default function SimulatePriceComponent({ title = "Pricing Simulator" }) 
 
       {(selectedPlan)
         ? <div className="pt-2">
-            <div className="text-xs lg:text-base col-span-2 text-sm text-slate-100 bg-gray-600 rounded-xl p-4 ">
+            <div className="lg:text-base col-span-2 text-sm text-slate-100 bg-gray-600 rounded-xl p-4 ">
               <label className="inline-block text-white font-medium mb-1">Capacity estimation</label>
               <p className="capacity-estimation" data-template="">
 
-                <span className="font-medium text-red-500">Resource-Intensive App</span>
+                <span className="font-medium text-green-500">Lightweight App</span>
                 <span> · {getEstimation(80)}</span>
                 <br />
 
@@ -230,7 +230,7 @@ export default function SimulatePriceComponent({ title = "Pricing Simulator" }) 
                 <span> · {getEstimation(500)}</span>
                 <br />
 
-                <span className="font-medium text-green-500">Lightweight App</span>
+                <span className="font-medium text-red-500">Resource-Intensive App</span>
                 <span> · {getEstimation(3000)}</span>
 
               </p>


### PR DESCRIPTION
Was browsing the Colyseus website when I noticed a potential bug 🐛

- Fixes what I believe is a misconfiguration in what you want to display for resource intensive vs. lightweight apps
- Removes dual tailwind specs for `text` size on default mode `text-xs text-sm` -> `text-sm`

Before:

<img width="2140" height="2468" alt="image" src="https://github.com/user-attachments/assets/b253e778-712f-41b1-9fb2-720486859635" />

After:

<img width="2104" height="2176" alt="image" src="https://github.com/user-attachments/assets/c0c77a5a-b390-4e5e-942e-587dc5ffc922" />
